### PR TITLE
Support matchFields for node selection

### DIFF
--- a/api/src/core/v1.rs
+++ b/api/src/core/v1.rs
@@ -282,7 +282,10 @@ pub struct NodeSelector {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeSelectorTerm {
+    #[serde(default)]
     pub match_expressions: Vec<NodeSelectorRequirement>,
+    #[serde(default)]
+    pub match_fields: Vec<NodeSelectorRequirement>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
This is missing enforcement of at-last-one of the match lists must be
populated, in the sense that a present node selector in a documented
with no match expressions is almost certainly a bug and it would be
nice to prevent those bugs.