### PR TITLE
Provide context with errors to help users

### DIFF
--- a/holding/src/client/mod.rs
+++ b/holding/src/client/mod.rs
@@ -17,6 +17,7 @@ use std::default::Default;
 use std::env;
 use std::fmt;
 use std::path::PathBuf;
+use std::str;
 use std::sync::Arc;
 use url::Url;
 
@@ -174,21 +175,72 @@ where
         //.inspect(|(_, body)| debug!("Response body: {:?}", ::std::str::from_utf8(body.as_ref())))
         .and_then(move |(httpstatus, body)| -> Result<T, Error> {
             if !httpstatus.is_success() {
+                // I think we can drop this debug! it is redundant with enrich_error.
                 debug!("failure body: {:#?}", ::std::str::from_utf8(body.as_ref()));
                 let status: Status = serde_json::from_slice(body.as_ref()).map_err(|e| {
                     debug!(
                         "Failed to parse error Status ({}), falling back to HTTP status",
-                        e
+                        enrich_error("error Status", &e, body.as_ref())
                     );
                     HttpStatusError { status: httpstatus }
                 })?;
                 Err(status.into())
             } else {
                 let o = serde_json::from_slice(body.as_ref())
-                    .with_context(|e| format!("Unable to parse response body: {}", e))?;
+                    .with_context(|e| enrich_error("response body", e, body.as_ref()))?;
                 Ok(o)
             }
         })
+}
+
+/// Grabs the 1K preceeding text from the failed document and describes the error.
+///
+/// TODO: handle multi-line JSON, just in case some API server decides to start emitting that.
+fn enrich_error(desc: &str, e: &serde_json::Error, body_ref: &[u8]) -> String {
+    // debug! so that operators running with debug logs get *everything*
+    debug!("Parse failure: {:#?}", body_ref);
+    // Provide a short snippet for errors that may be handled, logged at higher verbosity etc.
+    match e.classify() {
+        serde_json::error::Category::Io | serde_json::error::Category::Eof => {
+            format!("Unable to parse {}: {}", desc, e)
+        }
+        _ => {
+            // Either bad structure/values in the JSON (so show it) or bad contents (so show it)
+            // TODO: discard leading content? e.g. smaller but still debuggable?
+            let mut lines = str::from_utf8(body_ref).unwrap().lines();
+            let mut line_n = 1;
+            let mut line = lines.next().unwrap();
+            while line_n < e.line() {
+                line_n += 1;
+                line = lines.next().unwrap();
+            }
+            let start_n = if e.column() < 1024 {
+                0
+            } else {
+                e.column() - 1024
+            };
+            let body_snippet = &line[start_n..e.column()];
+            format!("Unable to parse {}: {} {}", desc, body_snippet, e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+    #[serde(rename_all = "camelCase")]
+    struct SampleObject {
+        pub required_field: String,
+    }
+
+    #[test]
+    fn test_enrich_error_short() {
+        let doc = "{\"doc\": 1}";
+        let formatted = serde_json::from_slice::<SampleObject>(doc.as_bytes())
+            .err()
+            .map(|e| super::enrich_error("error Status", &e, doc.as_bytes()));
+        assert_eq!(Some(String::from("Unable to parse error Status: {\"doc\": 1} missing field `requiredField` at line 1 column 10")), formatted);
+    }
 }
 
 fn do_watch<C, T>(
@@ -219,10 +271,12 @@ where
                         .concat2()
                         .from_err::<Error>()
                         .and_then(move |body| {
+                            // Redundant debug with enrich_error
                             debug!("failure body: {:#?}", ::std::str::from_utf8(body.as_ref()));
                             let status: Status = serde_json::from_slice(body.as_ref()).map_err(
                                 |e| {
-                                    debug!("Failed to parse error Status ({}), falling back to HTTP status", e);
+                                    debug!("Failed to parse error Status ({}), falling back to HTTP status", 
+                                        enrich_error("error Status", &e, body.as_ref()));
                                     HttpStatusError { status: httpstatus }
                                 },
                             )?;
@@ -241,7 +295,7 @@ where
                         })
                         .and_then(move |line| {
                             let o: T = serde_json::from_slice(line.as_ref())
-                                .with_context(|e| format!("Unable to parse watch line : {}", e))?;
+                                .with_context(|e| enrich_error("watch line", e, line.as_ref()))?;
                             Ok(o)
                         })
                 })


### PR DESCRIPTION
We currently flatten the serde_json errors into strings quite
early on, losing the ability to do structured reporting on the
underlying problem; this particularly shows up during API version
upgrades or when working on CRDs. Pulling out some context from the
bytes we're parsing helps (in the JSON case at least) without requiring
the operation to be repeatable with debug! logging.