### PR TITLE
Use JSON structure in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ kubernetes_holding = { path = "holding" }
 kubernetes_proxy = { path = "proxy" }
 
 [dev-dependencies]
+assert-json-diff = "^1"
 base64 = "^0.10"
 failure = "0.1"
 futures = "0.1.21"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 #[cfg(test)]
+#[macro_use]
+extern crate assert_json_diff;
+
+#[cfg(test)]
 extern crate failure;
 
 #[cfg(test)]


### PR DESCRIPTION
This lets us cleanly ignore the current encoding output differences
between kubernetes-rs and the reference golang code.